### PR TITLE
Nashville prefix support

### DIFF
--- a/src/music.ts
+++ b/src/music.ts
@@ -153,7 +153,7 @@ export class MusicNote extends AbstractNote {
  * Represents a Nashville number notation (1-7).
  */
 export class NashvilleNumber extends AbstractNote {
-    public static readonly PATTERN = /^([1-7])(#|♯|b|♭)?$/;
+    public static readonly PATTERN = /^(#|♯|b|♭)?([1-7])$/;
 
     /**
      * Create a new NashvilleNumber instance.
@@ -186,10 +186,41 @@ export class NashvilleNumber extends AbstractNote {
             throw new Error('Invalid note format');
         }
 
-        const root = match[1];
-        const postfix = match[2];
+        const prefix = match[1];
+        const root = match[2];
 
-        return new NashvilleNumber(parseInt(root), postfix);
+        return new NashvilleNumber(parseInt(root), prefix);
+    }
+
+    /**
+     * Convert the Nashville number to its string representation with accidental prefix.
+     * @param normalize If true, normalize accidentals to Unicode symbols (default: false)
+     */
+    toString(normalize: boolean = false): string {
+        let noteString = "";
+        
+        if (this.postfix) {
+            if (normalize) {
+                switch (this.accidental) {
+                    case Accidental.SHARP:
+                        noteString += '♯';
+                        break;
+                    case Accidental.FLAT:
+                        noteString += '♭';
+                        break;
+                    case Accidental.NATURAL:
+                    default:
+                        // no prefix for natural notes
+                        break;
+                }
+            } else {
+                noteString += this.postfix;
+            }
+        }
+        
+        noteString += this.root;
+        
+        return noteString;
     }
 }
 

--- a/src/music.ts
+++ b/src/music.ts
@@ -68,32 +68,35 @@ export abstract class AbstractNote {
     }
 
     /**
+     * Protected helper method to get the normalized accidental string.
+     * @param normalize If true, return Unicode symbols, otherwise return original postfix
+     */
+    protected accidentalToString(normalize: boolean): string {
+        if (!this.postfix) {
+            return "";
+        }
+
+        if (normalize) {
+            switch (this.accidental) {
+                case Accidental.SHARP:
+                    return '♯';
+                case Accidental.FLAT:
+                    return '♭';
+                case Accidental.NATURAL:
+                default:
+                    return ""; // no symbol for natural notes
+            }
+        }
+        
+        return this.postfix;
+    }
+
+    /**
      * Convert the note to its string representation.
      * @param normalize If true, normalize accidentals to Unicode symbols (default: false)
      */
     toString(normalize: boolean = false): string {
-        let noteString = this.root;
-        
-        if (this.postfix) {
-            if (normalize) {
-                switch (this.accidental) {
-                    case Accidental.SHARP:
-                        noteString += '♯';
-                        break;
-                    case Accidental.FLAT:
-                        noteString += '♭';
-                        break;
-                    case Accidental.NATURAL:
-                    default:
-                        // no postfix for natural notes
-                        break;
-                }
-            } else {
-                noteString += this.postfix;
-            }
-        }
-        
-        return noteString;
+        return this.root + this.accidentalToString(normalize);
     }
 
     /**
@@ -197,30 +200,7 @@ export class NashvilleNumber extends AbstractNote {
      * @param normalize If true, normalize accidentals to Unicode symbols (default: false)
      */
     toString(normalize: boolean = false): string {
-        let noteString = "";
-        
-        if (this.postfix) {
-            if (normalize) {
-                switch (this.accidental) {
-                    case Accidental.SHARP:
-                        noteString += '♯';
-                        break;
-                    case Accidental.FLAT:
-                        noteString += '♭';
-                        break;
-                    case Accidental.NATURAL:
-                    default:
-                        // no prefix for natural notes
-                        break;
-                }
-            } else {
-                noteString += this.postfix;
-            }
-        }
-        
-        noteString += this.root;
-        
-        return noteString;
+        return this.accidentalToString(normalize) + this.root;
     }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -141,7 +141,7 @@ export class LetterNotation extends ChordNotation {
  * Represents a chord notation using Nashville number system (1-7).
  */
 export class NashvilleNotation extends ChordNotation {
-    public static readonly PATTERN = /^\[([1-7](?:#|♯|b|♭)?)([^\/\]]+)?(?:\/(.+))?\]$/;
+    public static readonly PATTERN = /^\[((#|♯|b|♭)?[1-7])([^\/\]]+)?(?:\/(.+))?\]$/;
 
     constructor(
         public note: NashvilleNumber,
@@ -163,8 +163,8 @@ export class NashvilleNotation extends ChordNotation {
         }
 
         const noteString = match[1];
-        const modifier = match[2] && match[2].trim() !== '' ? match[2].trim() : undefined;
-        const bassString = match[3] ? match[3].trim() : undefined;
+        const modifier = match[3] && match[3].trim() !== '' ? match[3].trim() : undefined;
+        const bassString = match[4] ? match[4].trim() : undefined;
 
         if (!NashvilleNumber.test(noteString)) {
             throw new Error('Invalid Nashville notation: must use 1-7 numbers');

--- a/test/music.test.ts
+++ b/test/music.test.ts
@@ -24,7 +24,7 @@ describe("AbstractNote", () => {
 
     describe("handles Nashville numbers correctly", () => {
         const nashvilleNumberCases = [
-            "1", "4b", "2#", "7♯", "3♭"
+            "1", "b4", "#2", "♯7", "♭3"
         ];
 
         test.each(nashvilleNumberCases)("parses %s correctly", (input) => {
@@ -43,8 +43,8 @@ describe("AbstractNote", () => {
             // ASCII accidentals to Unicode
             { input: "F#", normalized: "F♯" },
             { input: "Bb", normalized: "B♭" },
-            { input: "2#", normalized: "2♯" },
-            { input: "4b", normalized: "4♭" },
+            { input: "#2", normalized: "♯2" },
+            { input: "b4", normalized: "♭4" },
             
             // Unicode accidentals
             { input: "B♮", normalized: "B" },
@@ -116,7 +116,7 @@ describe("MusicNote", () => {
     describe("error handling", () => {
         const invalidMusicNotes = [
             "1", "2", "3", "4", "5", "6", "7",
-            "1m", "4b", "2#", "7♯", "3♭"
+            "1m", "b4", "#2", "♯7", "♭3"
         ];
 
         test.each(invalidMusicNotes)("rejects Nashville number %s", (note) => {
@@ -135,11 +135,11 @@ describe("NashvilleNumber", () => {
         { input: "5", root: "5", postfix: undefined, accidental: Accidental.NATURAL },
         { input: "6", root: "6", postfix: undefined, accidental: Accidental.NATURAL },
         { input: "7", root: "7", postfix: undefined, accidental: Accidental.NATURAL },
-        { input: "4b", root: "4", postfix: "b", accidental: Accidental.FLAT },
-        { input: "2#", root: "2", postfix: "#", accidental: Accidental.SHARP },
-        { input: "7♯", root: "7", postfix: "♯", accidental: Accidental.SHARP },
-        { input: "3♭", root: "3", postfix: "♭", accidental: Accidental.FLAT },
-        { input: "3♯", root: "3", postfix: "♯", accidental: Accidental.SHARP },
+        { input: "b4", root: "4", postfix: "b", accidental: Accidental.FLAT },
+        { input: "#2", root: "2", postfix: "#", accidental: Accidental.SHARP },
+        { input: "♯7", root: "7", postfix: "♯", accidental: Accidental.SHARP },
+        { input: "♭3", root: "3", postfix: "♭", accidental: Accidental.FLAT },
+        { input: "♯3", root: "3", postfix: "♯", accidental: Accidental.SHARP },
     ];
 
     describe("parsing", () => {

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -71,8 +71,8 @@ describe("ChordNotation", () => {
     describe("handles Nashville notation correctly", () => {
         const nashvilleNotationCases = [
             "[1]",
-            "[4b7]",
-            "[4b7/5]",
+            "[b4m7]",
+            "[b4m7/5]",
             "[6m/4]",
         ];
 
@@ -89,8 +89,8 @@ describe("ChordNotation", () => {
             { input: "[F#m7]", normalized: "[F♯m7]" },
             { input: "[BbMAJ7]", normalized: "[B♭maj7]" },
             { input: "[F#m7/Bb]", normalized: "[F♯m7/B♭]" },
-            { input: "[2#m]", normalized: "[2♯m]" },
-            { input: "[4b7/5#]", normalized: "[4♭7/5♯]" },
+            { input: "[#2m]", normalized: "[♯2m]" },
+            { input: "[b4m7/#5]", normalized: "[♭4m7/♯5]" },
             { input: "[Fes]", normalized: "[F♭]" },
             { input: "[Gis]", normalized: "[G♯]" },
             
@@ -221,7 +221,7 @@ describe("LetterNotation", () => {
     describe("error handling", () => {
         const invalidLetterChords = [
             "[1]", "[2]", "[3]", "[4]", "[5]", "[6]", "[7]",
-            "[1m]", "[2m7]", "[4b7/5]", "[6m/4]"
+            "[1m]", "[2m7]", "[b4m7/5]", "[6m/4]"
         ];
 
         test.each(invalidLetterChords)("rejects Nashville notation %s", (chord) => {
@@ -240,18 +240,18 @@ describe("NashvilleNotation", () => {
         { input: "[5]", note: "5", modifier: undefined, bass: undefined, degree: 5 },
         { input: "[6]", note: "6", modifier: undefined, bass: undefined, degree: 6 },
         { input: "[7]", note: "7", modifier: undefined, bass: undefined, degree: 7 },
-        { input: "[1#]", note: "1#", modifier: undefined, bass: undefined, degree: 1 },
-        { input: "[2b]", note: "2b", modifier: undefined, bass: undefined, degree: 2 },
-        { input: "[3♯]", note: "3♯", modifier: undefined, bass: undefined, degree: 3 },
-        { input: "[4♭]", note: "4♭", modifier: undefined, bass: undefined, degree: 4 },
+        { input: "[#1]", note: "#1", modifier: undefined, bass: undefined, degree: 1 },
+        { input: "[b2]", note: "b2", modifier: undefined, bass: undefined, degree: 2 },
+        { input: "[♯3]", note: "♯3", modifier: undefined, bass: undefined, degree: 3 },
+        { input: "[♭4]", note: "♭4", modifier: undefined, bass: undefined, degree: 4 },
         { input: "[1m]", note: "1", modifier: "m", bass: undefined, degree: 1 },
         { input: "[2m7]", note: "2", modifier: "m7", bass: undefined, degree: 2 },
         { input: "[3maj7]", note: "3", modifier: "maj7", bass: undefined, degree: 3 },
-        { input: "[4b7]", note: "4b", modifier: "7", bass: undefined, degree: 4 },
-        { input: "[4b7/5]", note: "4b", modifier: "7", bass: "5", degree: 4 },
+        { input: "[b4m7]", note: "b4", modifier: "m7", bass: undefined, degree: 4 },
+        { input: "[b4m7/5]", note: "b4", modifier: "m7", bass: "5", degree: 4 },
         { input: "[1/3]", note: "1", modifier: undefined, bass: "3", degree: 1 },
         { input: "[6m/4]", note: "6", modifier: "m", bass: "4", degree: 6 },
-        { input: "[4♭7/5]", note: "4♭", modifier: "7", bass: "5", degree: 4 },
+        { input: "[♭4m7/5]", note: "♭4", modifier: "m7", bass: "5", degree: 4 },
     ];
 
     describe("parsing", () => {


### PR DESCRIPTION
Nashville numbers should accept the accidental before the degree, instead of after.