### PR TITLE
Switch flow to use local wiki links.

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -64,11 +64,12 @@ export class FlowGenerator {
 
         for (const item of flow) {
             if (typeof item === "string") {
-                if (item.startsWith("#")) {
-                    // Section reference - create transclusion
-                    insertText += `![[${file.basename}${item}]]\n`;
+                // check for local wiki links (format: [[#Section]])
+                const localWikiLinkMatch = item.match(/^\[\[#([^\]]+)\]\]$/);
+                if (localWikiLinkMatch) {
+                    const sectionName = localWikiLinkMatch[1];
+                    insertText += `![[${file.basename}#${sectionName}]]\n`;
                 } else {
-                    // Markdown content
                     insertText += `${item}\n`;
                 }
             }

--- a/test/standard.md
+++ b/test/standard.md
@@ -5,13 +5,13 @@ time: 3/4
 key: C
 tempo: 80
 flow:
-  - "#Verse 1"
-  - "#Verse 2"
-  - "#Verse 3"
+  - "[[#Verse 1]]"
+  - "[[#Verse 2]]"
+  - "[[#Verse 3]]"
   - ""
   - ">[!note] Key Change"
   - ""
-  - "#Verse 4"
+  - "[[#Verse 4]]"
 ---
 
 # Amazing Grace


### PR DESCRIPTION
Instead of processing tag lines as flow links, look for local wiki links (e.g. `[[#Verse]]`) instead.