### PR TITLE
[Dev] Archive files in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,11 +30,14 @@ jobs:
               id: version
               run: echo "VERSION=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
+            - name: Create release archive
+              run: zip -j "obsidian-chopro-${{ github.ref_name }}.zip" ./main.js ./manifest.json ./styles.css
+
             - name: Create release
               run: |
                   gh release create ${{ github.ref_name }} \
                     --title "obsidian-chopro-${{ github.ref_name }}" \
                     --generate-notes --draft \
-                    ./main.js ./manifest.json ./styles.css
+                    "obsidian-chopro-${{ github.ref_name }}.zip"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Instead of giving the user the files they need to download individually, this change updates the release workflow to add all required files to an archive so the user only needs to download and extract that one thing.

Fairly small change but it's something I noticed when installing the plugin! Thanks for your good work here

NOTE: I was unable to test this using Github Actions on my fork, but I based this off an approach I've used before. I'm open to ideas on how to test this!