### PR TITLE
feat: add configurable chord pair margin

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export interface RenderSettings {
     chordDecorations: string;
     normalizedChordDisplay: boolean;
     italicAnnotations: boolean;
+    chordPairSpacing: number;
 }
 
 export interface FlowSettings {

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,6 +23,7 @@ const DEFAULT_SETTINGS: ChoproPluginSettings = {
         chordDecorations: "none",
         normalizedChordDisplay: false,
         italicAnnotations: true,
+        chordPairSpacing: 0.1, // em
     },
     flow: {
         filesFolder: "",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -74,6 +74,42 @@ class ChordSize extends SliderSetting {
 }
 
 /**
+ * User setting for chord pair spacing.
+ */
+class ChordPairSpacing extends SliderSetting {
+    constructor(private plugin: ChoproPlugin) {
+        super({
+            name: "Chord pair spacing",
+            description: "Horizontal spacing between chord-lyric pairs",
+        });
+    }
+
+    get value(): number {
+        return this.plugin.settings.rendering.chordPairSpacing;
+    }
+
+    set value(value: number) {
+        this.plugin.settings.rendering.chordPairSpacing = value;
+    }
+
+    get default(): number {
+        return 0.1;
+    }
+
+    get minimum(): number {
+        return 0;
+    }
+
+    get maximum(): number {
+        return 1.0;
+    }
+
+    get step(): number {
+        return 0.1;
+    }
+}
+
+/**
  * User setting for superscript chord modifiers.
  */
 class SuperscriptChordMods extends ToggleSetting {
@@ -275,6 +311,12 @@ class DisplaySettings extends SettingsTabPage {
             .display(containerEl);
 
         new ChordSize(this.plugin)
+            .onChange((_value) => {
+                updatePreview();
+            })
+            .display(containerEl);
+
+        new ChordPairSpacing(this.plugin)
             .onChange((_value) => {
                 updatePreview();
             })

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -28,7 +28,8 @@ export class ChoproStyleManager {
 
             // Validate and sanitize color value
             const colorValue = this.sanitizeColorValue(settings.chordColor);
-            const sizeValue = this.sanitizeSizeValue(settings.chordSize);
+            const sizeValue = this.clamp(settings.chordSize, 0.5, 3.0, 1.0);
+            const spacingValue = this.clamp(settings.chordPairSpacing, 0, 1.0, 0.1);
 
             // Chord and annotation color and size overrides
             overrides += `
@@ -39,6 +40,13 @@ export class ChoproStyleManager {
                 }
                 .chopro-line:has(.chopro-pair) {
                     min-height: ${1.5 + sizeValue}em;
+                }
+            `;
+
+            // Chord pair spacing override
+            overrides += `
+                .chopro-pair {
+                    margin-right: ${spacingValue}em;
                 }
             `;
 
@@ -79,11 +87,10 @@ export class ChoproStyleManager {
         return colorPattern.test(color.trim()) ? color.trim() : "#2563eb";
     }
 
-    private static sanitizeSizeValue(size: number): number {
-        // Ensure size is within reasonable bounds
-        if (typeof size !== "number" || isNaN(size)) {
-            return 1.0;
+    private static clamp(value: number, min: number, max: number, fallback: number): number {
+        if (typeof value !== "number" || isNaN(value)) {
+            return fallback;
         }
-        return Math.max(0.5, Math.min(3.0, size));
+        return Math.max(min, Math.min(max, value));
     }
 }


### PR DESCRIPTION
## What it does

- Adds a plugin configuration option to control the margin between chord pairs

## Notes

- This might be niche so no worries if you aren't interested in adding this!
- I keep saying "chord pairs" for lack of a better term, but I don't think that's entirely right. I'm open to suggestions if you'd like me to rename the UI elements
- This plugin is opt-in and by default has no changes for existing users

## Screenshots

**The plugin settings page**
![Screenshot 2025-11-12 at 12 08 55 PM](https://github.com/user-attachments/assets/e0824d79-a122-4710-9242-8c277a4718d4)

**The plugin with spacing set to 0**
![Screenshot 2025-11-12 at 12 08 45 PM](https://github.com/user-attachments/assets/f5649fac-2b62-4ac9-b0f6-47c5bf2565e4)

**The plugin with spacing set to 0.5**
![Screenshot 2025-11-12 at 12 09 05 PM](https://github.com/user-attachments/assets/d4675d18-6d1c-4bd7-b780-c6acf030b3de)
