### PR TITLE
feat(flow): resolve flow content in reading view

### DIFF
--- a/src/callout.ts
+++ b/src/callout.ts
@@ -1,12 +1,9 @@
 // callout - ChoPro callout processor for Obsidian
 
 import { Logger } from "obskit";
-import { TFile, MarkdownPostProcessorContext, Plugin, MarkdownRenderer, parseYaml } from "obsidian";
+import { TFile, MarkdownPostProcessorContext, MarkdownRenderer, parseYaml } from "obsidian";
 
-import { FlowManager } from "./flow";
-import { ContentRenderer } from "./render";
-import { ChoproFile } from "./parser";
-import { RenderSettings } from "./config";
+import type ChoproPlugin from "./main";
 
 const TRUTHY_VALUES = ["on", "true", "yes", "y"];
 
@@ -37,21 +34,10 @@ export interface CalloutFeatures {
 export class CalloutProcessor {
     private logger = Logger.getLogger("CalloutProcessor");
 
-    private plugin: Plugin;
-    private flowManager: FlowManager;
-    private renderer: ContentRenderer;
-    private renderSettings: RenderSettings;
+    private plugin: ChoproPlugin;
 
-    constructor(
-        plugin: Plugin,
-        flowManager: FlowManager,
-        renderer: ContentRenderer,
-        renderSettings: RenderSettings
-    ) {
+    constructor(plugin: ChoproPlugin) {
         this.plugin = plugin;
-        this.flowManager = flowManager;
-        this.renderer = renderer;
-        this.renderSettings = renderSettings;
     }
 
     /**
@@ -165,26 +151,20 @@ export class CalloutProcessor {
     ): Promise<void> {
         callout.empty();
 
-        let content: string;
-
-        if (features.flow && this.flowManager.hasFlowDefinition(file)) {
-            this.logger.debug("Rendering flow content");
-            content = await this.flowManager.getResolvedFlowContent(file);
-        } else {
-            this.logger.debug("Rendering markdown content");
-            content = await this.plugin.app.vault.read(file);
-        }
-
         const container = callout.createEl("blockquote");
+        container.addClass("chopro-flow-rendered");
 
-        // Render per-song metadata header from the target file's frontmatter
-        if (this.renderSettings.showMetadataHeader) {
-            const parsed = ChoproFile.parse(content);
-            if (parsed.frontmatter) {
-                this.renderer.renderMetadataHeader(parsed.frontmatter, container);
-            }
+        if (features.flow) {
+            await this.plugin.renderChoproFile(file, container, file.path);
+        } else {
+            const content = await this.plugin.app.vault.read(file);
+            await MarkdownRenderer.render(
+                this.plugin.app,
+                content,
+                container,
+                file.path,
+                this.plugin
+            );
         }
-
-        await MarkdownRenderer.render(this.plugin.app, content, container, file.path, this.plugin);
     }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export type RenderSettings = {
 export type FlowSettings = {
     filesFolder: string;
     extraLine: boolean;
+    resolveFlowInReadingView: boolean;
 };
 
 export type ChoproPluginSettings = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,6 @@ export default class ChoproPlugin extends Plugin {
     renderer: ContentRenderer;
     flowManager: FlowManager;
     calloutProcessor: CalloutProcessor;
-    private flowProcessedDocs = new Set<string>();
 
     private logger: Logger = Logger.getLogger("main");
 
@@ -244,21 +243,24 @@ export default class ChoproPlugin extends Plugin {
             return;
         }
 
-        // Use docId to track first-seen section per render pass.
-        // Subsequent sections of the same render pass get emptied so the
-        // resolved flow content (rendered into the first section) is the
-        // only visible content.
-        const renderKey = `${ctx.docId}:${ctx.sourcePath}`;
-
-        if (this.flowProcessedDocs.has(renderKey)) {
-            el.empty();
-            return;
+        // Defer until el is attached to its parent so we can inspect siblings
+        if (!el.parentElement) {
+            await new Promise<void>((resolve) => queueMicrotask(resolve));
         }
 
-        this.flowProcessedDocs.add(renderKey);
-        // Schedule cleanup so the entry doesn't leak after the render pass
-        setTimeout(() => this.flowProcessedDocs.delete(renderKey), 5000);
+        // If a previous sibling has already been rendered as flow content,
+        // this section is a follow-up of the same render pass — empty it.
+        let sibling = el.previousElementSibling;
+        while (sibling) {
+            if (sibling.classList.contains("chopro-flow-rendered")) {
+                el.empty();
+                return;
+            }
+            sibling = sibling.previousElementSibling;
+        }
 
+        // Synchronously mark this element so subsequent siblings detect it
+        // even before our async render completes.
         el.empty();
         el.addClass("chopro-flow-rendered");
 
@@ -283,13 +285,6 @@ export default class ChoproPlugin extends Plugin {
             content = await this.flowManager.getResolvedFlowContent(file);
         } else {
             content = await this.app.vault.read(file);
-        }
-
-        if (this.settings.rendering.showMetadataHeader) {
-            const parsed = ChoproFile.parse(content);
-            if (parsed.frontmatter) {
-                this.renderer.renderMetadataHeader(parsed.frontmatter, container);
-            }
         }
 
         await MarkdownRenderer.render(this.app, content, container, sourcePath, this);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
     Editor,
     MarkdownPostProcessorContext,
     MarkdownRenderer,
+    TFile,
 } from "obsidian";
 
 import { ChoproFile, Frontmatter } from "./parser";
@@ -48,8 +49,8 @@ export default class ChoproPlugin extends Plugin {
     settings: ChoproPluginSettings;
     renderer: ContentRenderer;
     flowManager: FlowManager;
-    private flowRenderInProgress = false;
     calloutProcessor: CalloutProcessor;
+    private flowProcessedDocs = new Set<string>();
 
     private logger: Logger = Logger.getLogger("main");
 
@@ -64,20 +65,19 @@ export default class ChoproPlugin extends Plugin {
 
         this.registerMarkdownPostProcessor(
             async (el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+                await this.processFlowFile(el, ctx);
                 await this.calloutProcessor.processCallouts(el, ctx);
             }
         );
 
         this.registerEvent(
             this.app.workspace.on("active-leaf-change", () => {
-                this.updateFlowReadingView();
                 this.updateMetadataHeader();
             })
         );
 
         this.registerEvent(
             this.app.workspace.on("layout-change", () => {
-                this.updateFlowReadingView();
                 this.updateMetadataHeader();
             })
         );
@@ -134,12 +134,7 @@ export default class ChoproPlugin extends Plugin {
             MarkdownRenderer.render(this.app, content, container, "", this)
         );
         this.flowManager = new FlowManager(this, this.settings.flow);
-        this.calloutProcessor = new CalloutProcessor(
-            this,
-            this.flowManager,
-            this.renderer,
-            this.settings.rendering
-        );
+        this.calloutProcessor = new CalloutProcessor(this);
 
         ChoproStyleManager.updateAllContainers(this.settings.rendering);
     }
@@ -223,42 +218,25 @@ export default class ChoproPlugin extends Plugin {
     }
 
     /**
-     * Resolve flow content and render it in reading view, replacing the
-     * default preview with fully resolved flow markdown.
+     * Markdown post-processor that detects flow files and replaces their
+     * rendered content with the resolved flow arrangement. Runs in both
+     * reading view and PDF export since both use the same pipeline.
      */
-    private async updateFlowReadingView(): Promise<void> {
-        if (this.flowRenderInProgress) {
-            return;
-        }
-
-        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
-        if (!view) {
-            return;
-        }
-
-        const contentEl = view.contentEl;
-        const readingViewEl = contentEl.querySelector(".markdown-reading-view");
-
-        // Remove any existing flow overlays
-        readingViewEl
-            ?.querySelectorAll(":scope > .chopro-flow-content")
-            .forEach((el) => el.remove());
-
-        // Un-hide the original preview if it was hidden
-        const previewEl = contentEl.querySelector(".markdown-preview-view");
-        previewEl?.removeClass("chopro-flow-hidden");
-
+    private async processFlowFile(
+        el: HTMLElement,
+        ctx: MarkdownPostProcessorContext
+    ): Promise<void> {
         if (!this.settings.flow.resolveFlowInReadingView) {
             return;
         }
 
-        // Only show in reading view
-        if (view.getMode() !== "preview") {
+        // Recursion guard: skip if we're already inside a flow-rendered block
+        if (el.closest(".chopro-flow-rendered")) {
             return;
         }
 
-        const file = view.file;
-        if (!file || !readingViewEl) {
+        const file = this.app.vault.getAbstractFileByPath(ctx.sourcePath);
+        if (!(file instanceof TFile)) {
             return;
         }
 
@@ -266,41 +244,55 @@ export default class ChoproPlugin extends Plugin {
             return;
         }
 
-        this.flowRenderInProgress = true;
+        // Use docId to track first-seen section per render pass.
+        // Subsequent sections of the same render pass get emptied so the
+        // resolved flow content (rendered into the first section) is the
+        // only visible content.
+        const renderKey = `${ctx.docId}:${ctx.sourcePath}`;
+
+        if (this.flowProcessedDocs.has(renderKey)) {
+            el.empty();
+            return;
+        }
+
+        this.flowProcessedDocs.add(renderKey);
+        // Schedule cleanup so the entry doesn't leak after the render pass
+        setTimeout(() => this.flowProcessedDocs.delete(renderKey), 5000);
+
+        el.empty();
+        el.addClass("chopro-flow-rendered");
 
         try {
-            const resolvedContent = await this.flowManager.getResolvedFlowContent(file);
-
-            // Hide the original preview
-            previewEl?.addClass("chopro-flow-hidden");
-
-            // Create flow overlay with Obsidian reading view classes for consistent styling
-            const flowContainer = readingViewEl.createDiv({
-                cls: "chopro-flow-content markdown-preview-view markdown-rendered",
-            });
-            const flowSizer = flowContainer.createDiv({
-                cls: "markdown-preview-sizer markdown-preview-section",
-            });
-
-            await MarkdownRenderer.render(this.app, resolvedContent, flowSizer, file.path, this);
-
-            this.logger.debug("Flow reading view rendered");
+            await this.renderChoproFile(file, el, ctx.sourcePath);
+            this.logger.debug(`Flow rendered for ${file.path}`);
         } catch (error) {
-            this.logger.error("Failed to render flow reading view:", error);
-
-            // Clean up on error
-            previewEl?.removeClass("chopro-flow-hidden");
-            readingViewEl
-                ?.querySelectorAll(":scope > .chopro-flow-content")
-                .forEach((el) => el.remove());
-
-            const errorDiv = readingViewEl?.createDiv({
-                cls: "chopro-flow-content chopro-flow-error",
-            });
-            errorDiv?.setText("Error resolving flow content");
-        } finally {
-            this.flowRenderInProgress = false;
+            this.logger.error("Failed to render flow content:", error);
+            el.createDiv({ cls: "chopro-flow-error", text: "Error resolving flow content" });
         }
+    }
+
+    /**
+     * Render a chopro file into a container, resolving flow content if the
+     * file has a flow definition. Used by both the file-level flow processor
+     * and the callout processor.
+     */
+    async renderChoproFile(file: TFile, container: HTMLElement, sourcePath: string): Promise<void> {
+        let content: string;
+
+        if (this.flowManager.hasFlowDefinition(file)) {
+            content = await this.flowManager.getResolvedFlowContent(file);
+        } else {
+            content = await this.app.vault.read(file);
+        }
+
+        if (this.settings.rendering.showMetadataHeader) {
+            const parsed = ChoproFile.parse(content);
+            if (parsed.frontmatter) {
+                this.renderer.renderMetadataHeader(parsed.frontmatter, container);
+            }
+        }
+
+        await MarkdownRenderer.render(this.app, content, container, sourcePath, this);
     }
 
     /**
@@ -329,11 +321,6 @@ export default class ChoproPlugin extends Plugin {
 
         const file = view.file;
         if (!file) {
-            return;
-        }
-
-        // Skip when flow overlay is active
-        if (contentEl.querySelector(".chopro-flow-content")) {
             return;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,7 @@ const DEFAULT_SETTINGS: ChoproPluginSettings = {
     flow: {
         filesFolder: "",
         extraLine: true,
+        resolveFlowInReadingView: true,
     },
     logLevel: LogLevel.ERROR,
 };
@@ -68,12 +69,14 @@ export default class ChoproPlugin extends Plugin {
 
         this.registerEvent(
             this.app.workspace.on("active-leaf-change", () => {
+                this.updateFlowReadingView();
                 this.updateMetadataHeader();
             })
         );
 
         this.registerEvent(
             this.app.workspace.on("layout-change", () => {
+                this.updateFlowReadingView();
                 this.updateMetadataHeader();
             })
         );
@@ -219,6 +222,73 @@ export default class ChoproPlugin extends Plugin {
     }
 
     /**
+     * Resolve flow content and render it in reading view, replacing the
+     * default preview with fully resolved flow markdown.
+     */
+    private async updateFlowReadingView(): Promise<void> {
+        const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+        if (!view) {
+            return;
+        }
+
+        const contentEl = view.contentEl;
+
+        // Remove any existing flow overlay
+        contentEl.querySelector(":scope > .chopro-flow-content")?.remove();
+
+        // Un-hide the original preview if it was hidden
+        const previewEl = contentEl.querySelector(".markdown-preview-view");
+        previewEl?.removeClass("chopro-flow-hidden");
+
+        if (!this.settings.flow.resolveFlowInReadingView) {
+            return;
+        }
+
+        // Only show in reading view
+        if (view.getMode() !== "preview") {
+            return;
+        }
+
+        const file = view.file;
+        if (!file) {
+            return;
+        }
+
+        if (!this.flowManager.hasFlowDefinition(file)) {
+            return;
+        }
+
+        try {
+            const resolvedContent = await this.flowManager.getResolvedFlowContent(file);
+
+            // Hide the original preview
+            previewEl?.addClass("chopro-flow-hidden");
+
+            // Create flow overlay as a sibling
+            const flowContainer = contentEl.createDiv({ cls: "chopro-flow-content" });
+
+            await MarkdownRenderer.render(
+                this.app,
+                resolvedContent,
+                flowContainer,
+                file.path,
+                this
+            );
+
+            this.logger.debug("Flow reading view rendered");
+        } catch (error) {
+            this.logger.error("Failed to render flow reading view:", error);
+
+            // Clean up on error
+            previewEl?.removeClass("chopro-flow-hidden");
+            contentEl.querySelector(":scope > .chopro-flow-content")?.remove();
+
+            const errorDiv = contentEl.createDiv({ cls: "chopro-flow-content chopro-flow-error" });
+            errorDiv.setText("Error resolving flow content");
+        }
+    }
+
+    /**
      * Update the document-level metadata header.
      * Removes any existing header and re-injects if appropriate.
      */
@@ -244,6 +314,11 @@ export default class ChoproPlugin extends Plugin {
 
         const file = view.file;
         if (!file) {
+            return;
+        }
+
+        // Skip when flow overlay is active
+        if (contentEl.querySelector(":scope > .chopro-flow-content")) {
             return;
         }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,7 @@ export default class ChoproPlugin extends Plugin {
     settings: ChoproPluginSettings;
     renderer: ContentRenderer;
     flowManager: FlowManager;
+    private flowRenderInProgress = false;
     calloutProcessor: CalloutProcessor;
 
     private logger: Logger = Logger.getLogger("main");
@@ -226,15 +227,22 @@ export default class ChoproPlugin extends Plugin {
      * default preview with fully resolved flow markdown.
      */
     private async updateFlowReadingView(): Promise<void> {
+        if (this.flowRenderInProgress) {
+            return;
+        }
+
         const view = this.app.workspace.getActiveViewOfType(MarkdownView);
         if (!view) {
             return;
         }
 
         const contentEl = view.contentEl;
+        const readingViewEl = contentEl.querySelector(".markdown-reading-view");
 
-        // Remove any existing flow overlay
-        contentEl.querySelector(":scope > .chopro-flow-content")?.remove();
+        // Remove any existing flow overlays
+        readingViewEl
+            ?.querySelectorAll(":scope > .chopro-flow-content")
+            .forEach((el) => el.remove());
 
         // Un-hide the original preview if it was hidden
         const previewEl = contentEl.querySelector(".markdown-preview-view");
@@ -250,7 +258,7 @@ export default class ChoproPlugin extends Plugin {
         }
 
         const file = view.file;
-        if (!file) {
+        if (!file || !readingViewEl) {
             return;
         }
 
@@ -258,22 +266,23 @@ export default class ChoproPlugin extends Plugin {
             return;
         }
 
+        this.flowRenderInProgress = true;
+
         try {
             const resolvedContent = await this.flowManager.getResolvedFlowContent(file);
 
             // Hide the original preview
             previewEl?.addClass("chopro-flow-hidden");
 
-            // Create flow overlay as a sibling
-            const flowContainer = contentEl.createDiv({ cls: "chopro-flow-content" });
+            // Create flow overlay with Obsidian reading view classes for consistent styling
+            const flowContainer = readingViewEl.createDiv({
+                cls: "chopro-flow-content markdown-preview-view markdown-rendered",
+            });
+            const flowSizer = flowContainer.createDiv({
+                cls: "markdown-preview-sizer markdown-preview-section",
+            });
 
-            await MarkdownRenderer.render(
-                this.app,
-                resolvedContent,
-                flowContainer,
-                file.path,
-                this
-            );
+            await MarkdownRenderer.render(this.app, resolvedContent, flowSizer, file.path, this);
 
             this.logger.debug("Flow reading view rendered");
         } catch (error) {
@@ -281,10 +290,16 @@ export default class ChoproPlugin extends Plugin {
 
             // Clean up on error
             previewEl?.removeClass("chopro-flow-hidden");
-            contentEl.querySelector(":scope > .chopro-flow-content")?.remove();
+            readingViewEl
+                ?.querySelectorAll(":scope > .chopro-flow-content")
+                .forEach((el) => el.remove());
 
-            const errorDiv = contentEl.createDiv({ cls: "chopro-flow-content chopro-flow-error" });
-            errorDiv.setText("Error resolving flow content");
+            const errorDiv = readingViewEl?.createDiv({
+                cls: "chopro-flow-content chopro-flow-error",
+            });
+            errorDiv?.setText("Error resolving flow content");
+        } finally {
+            this.flowRenderInProgress = false;
         }
     }
 
@@ -318,7 +333,7 @@ export default class ChoproPlugin extends Plugin {
         }
 
         // Skip when flow overlay is active
-        if (contentEl.querySelector(":scope > .chopro-flow-content")) {
+        if (contentEl.querySelector(".chopro-flow-content")) {
             return;
         }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -230,6 +230,31 @@ class SongFolder extends TextInputSetting {
 }
 
 /**
+ * User setting for resolving flow in reading view.
+ */
+class ResolveFlowInReadingView extends ToggleSetting {
+    constructor(private plugin: ChoproPlugin) {
+        super({
+            name: "Resolve flow in reading view",
+            description:
+                "Render resolved flow content directly in reading view without requiring a callout block",
+        });
+    }
+
+    get value(): boolean {
+        return this.plugin.settings.flow.resolveFlowInReadingView;
+    }
+
+    set value(value: boolean) {
+        this.plugin.settings.flow.resolveFlowInReadingView = value;
+    }
+
+    get default(): boolean {
+        return true;
+    }
+}
+
+/**
  * User setting for blank lines in flow.
  */
 class BlankLinesInFlow extends ToggleSetting {
@@ -372,6 +397,7 @@ class FlowSettings extends SettingsTabPage {
     display(containerEl: HTMLElement): void {
         new SongFolder(this.plugin).display(containerEl);
         new BlankLinesInFlow(this.plugin).display(containerEl);
+        new ResolveFlowInReadingView(this.plugin).display(containerEl);
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -184,27 +184,6 @@
 }
 
 /* ===== Flow Reading View Styles ===== */
-.chopro-flow-hidden {
-    display: none;
-}
-
-.view-content:has(.chopro-flow-content) {
-    display: flex;
-    flex-direction: column;
-}
-
-.view-content:has(.chopro-flow-content) > .markdown-reading-view {
-    flex: 1;
-    min-height: 0;
-    position: relative;
-}
-
-.chopro-flow-content.markdown-preview-view {
-    position: absolute;
-    inset: 0;
-    overflow: auto;
-}
-
 .chopro-flow-error {
     color: var(--text-error);
     font-style: italic;

--- a/styles.css
+++ b/styles.css
@@ -182,3 +182,17 @@
 .callout[data-callout="chopro"] .chopro-header {
     padding: 1rem 0;
 }
+
+/* ===== Flow Reading View Styles ===== */
+.chopro-flow-hidden {
+    display: none;
+}
+
+.chopro-flow-content {
+    padding: var(--file-margins);
+}
+
+.chopro-flow-error {
+    color: var(--text-error);
+    font-style: italic;
+}

--- a/styles.css
+++ b/styles.css
@@ -188,8 +188,21 @@
     display: none;
 }
 
-.chopro-flow-content {
-    padding: var(--file-margins);
+.view-content:has(.chopro-flow-content) {
+    display: flex;
+    flex-direction: column;
+}
+
+.view-content:has(.chopro-flow-content) > .markdown-reading-view {
+    flex: 1;
+    min-height: 0;
+    position: relative;
+}
+
+.chopro-flow-content.markdown-preview-view {
+    position: absolute;
+    inset: 0;
+    overflow: auto;
 }
 
 .chopro-flow-error {


### PR DESCRIPTION
## Summary

- When a file defines a `flow` array in frontmatter, reading view now renders the resolved flow content (assembled sections in order) instead of the raw file content
- Adds a `resolveFlowInReadingView` setting (default: on) to control this behavior
- Reuses existing `FlowManager.getResolvedFlowContent()` — no changes to flow resolution logic

Closes #275

## Test plan

- [ ] Open a file with a `flow` frontmatter array in reading view — should show resolved sections in flow order
- [ ] Toggle between edit and reading view — content should switch cleanly without duplication
- [ ] Click away to another file and back while in reading view — no duplicate sections
- [ ] Open a file without `flow` frontmatter — standard reading view unchanged
- [ ] Disable "Resolve flow in reading view" in settings — flow files show raw content
- [ ] Verify styling matches standard reading view (heading sizes, margins, readable line length)
- [ ] Verify callout-based flow rendering still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)