### PR TITLE
refactor: replace explicit any with unknown and concrete types

### DIFF
--- a/src/callout.ts
+++ b/src/callout.ts
@@ -13,9 +13,9 @@ const TRUTHY_VALUES = ["on", "true", "yes", "y"];
 /**
  * Returns true if the value is a common boolean.
  */
-function isTruthy(value: any): boolean {
+function isTruthy(value: unknown): boolean {
     if (typeof value === "boolean") {
-        return value as boolean;
+        return value;
     }
 
     if (typeof value === "string") {
@@ -134,7 +134,7 @@ export class CalloutProcessor {
 
             if (yamlData && typeof yamlData === "object") {
                 this.logger.debug("Parsed YAML data:", yamlData);
-                this.mergeFeatures(features, yamlData);
+                this.mergeFeatures(features, yamlData as Record<string, unknown>);
             } else {
                 this.logger.warn("Unable to parse features");
             }
@@ -148,7 +148,7 @@ export class CalloutProcessor {
     /**
      * Merge features from YAML into the features object.
      */
-    private mergeFeatures(features: CalloutFeatures, yaml: any): void {
+    private mergeFeatures(features: CalloutFeatures, yaml: Record<string, unknown>): void {
         if ("flow" in yaml) {
             this.logger.debug(`flow :: ${yaml.flow}`);
             features.flow = isTruthy(yaml.flow);

--- a/src/main.ts
+++ b/src/main.ts
@@ -260,7 +260,7 @@ export default class ChoproPlugin extends Plugin {
             return;
         }
 
-        const metadata = new Frontmatter(frontmatter as Record<string, any>);
+        const metadata = new Frontmatter(frontmatter as Record<string, unknown>);
         const header = this.createMetadataHeader(metadata);
 
         if (header) {

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -1,7 +1,16 @@
 // modals - Modal classes for the ChoPro Obsidian Plugin
 
 import { Logger } from "obskit";
-import { App, Modal, Setting, ButtonComponent, Notice, TFile, FuzzySuggestModal } from "obsidian";
+import {
+    App,
+    Modal,
+    Setting,
+    ButtonComponent,
+    DropdownComponent,
+    Notice,
+    TFile,
+    FuzzySuggestModal,
+} from "obsidian";
 
 import { TransposeOptions, TransposeUtils } from "./transpose";
 
@@ -67,7 +76,7 @@ export class TransposeModal extends Modal {
                     })
             );
 
-        let targetKeyDropdown: any;
+        let targetKeyDropdown!: DropdownComponent;
         const targetKeySetting = new Setting(contentEl)
             .setName("Target Key")
             .setDesc("Choose the key to transpose to")

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -644,7 +644,7 @@ export abstract class ContentBlock {
 export class Frontmatter extends ContentBlock {
     public static readonly BLOCK_PATTERN = /^---\n(([\s\S]*)\n)?---$/;
 
-    constructor(public properties: Record<string, any> = {}) {
+    constructor(public properties: Record<string, unknown> = {}) {
         super();
     }
 
@@ -671,7 +671,7 @@ export class Frontmatter extends ContentBlock {
     /**
      * Extract the frontmatter records from a string.
      */
-    private static extract(content: string): Record<string, any> | undefined {
+    private static extract(content: string): Record<string, unknown> | undefined {
         const match = content.match(Frontmatter.BLOCK_PATTERN);
 
         if (!match) {
@@ -679,7 +679,7 @@ export class Frontmatter extends ContentBlock {
         }
 
         try {
-            return parseYaml(match[1]) as Record<string, any>;
+            return parseYaml(match[1]) as Record<string, unknown>;
         } catch (error) {
             console.warn("Failed to parse frontmatter:", error);
         }
@@ -690,14 +690,14 @@ export class Frontmatter extends ContentBlock {
     /**
      * Get a property value by key.
      */
-    get(key: string): any {
+    get(key: string): unknown {
         return this.properties[key];
     }
 
     /**
      * Set a property value.
      */
-    set(key: string, value: any): void {
+    set(key: string, value: unknown): void {
         this.properties[key] = value;
     }
 
@@ -858,7 +858,8 @@ export class ChoproFile {
      * Get the key from the file properties, or undefined if none exists.
      */
     get key(): string | undefined {
-        return this.frontmatter?.get("key");
+        const value = this.frontmatter?.get("key");
+        return value != null ? String(value) : undefined;
     }
 
     /**

--- a/src/render.ts
+++ b/src/render.ts
@@ -96,6 +96,12 @@ export class ContentRenderer {
         const tempo = frontmatter.get("tempo");
         const time = frontmatter.get("time");
 
+        const titleText = title != null ? String(title) : undefined;
+        const artistText = artist != null ? String(artist) : undefined;
+        const keyText = key != null ? String(key) : undefined;
+        const tempoText = tempo != null ? String(tempo) : undefined;
+        const timeText = time != null ? String(time) : undefined;
+
         // Only render if we have at least title or artist
         if (!title && !artist) {
             this.logger.debug("No title or artist found, skipping metadata header");
@@ -107,30 +113,30 @@ export class ContentRenderer {
         // Left column: title and artist
         const leftCol = header.createDiv({ cls: "chopro-header-left" });
 
-        if (title) {
-            leftCol.createDiv({ cls: "chopro-header-title", text: title });
+        if (titleText) {
+            leftCol.createDiv({ cls: "chopro-header-title", text: titleText });
         }
-        if (artist) {
-            leftCol.createDiv({ cls: "chopro-header-artist", text: artist });
+        if (artistText) {
+            leftCol.createDiv({ cls: "chopro-header-artist", text: artistText });
         }
 
         // Right column: key and tempo/time info
         const rightCol = header.createDiv({ cls: "chopro-header-right" });
 
-        if (key) {
-            rightCol.createDiv({ cls: "chopro-header-info", text: `Key of ${key}` });
+        if (keyText) {
+            rightCol.createDiv({ cls: "chopro-header-info", text: `Key of ${keyText}` });
         }
 
         // Build tempo/time line (e.g., "85 BPM in 4/4")
         const tempoTimeParts: string[] = [];
-        if (tempo) {
-            tempoTimeParts.push(`${tempo} BPM`);
+        if (tempoText) {
+            tempoTimeParts.push(`${tempoText} BPM`);
         }
-        if (tempo && time) {
+        if (tempoText && timeText) {
             tempoTimeParts.push("in");
         }
-        if (time) {
-            tempoTimeParts.push(time);
+        if (timeText) {
+            tempoTimeParts.push(timeText);
         }
         if (tempoTimeParts.length > 0) {
             rightCol.createDiv({ cls: "chopro-header-info", text: tempoTimeParts.join(" ") });


### PR DESCRIPTION
## Summary
- Replace `any` with `unknown` in `Frontmatter` properties/get/set and the callout YAML feature merger
- Use `Record<string, unknown>` for frontmatter casts in `main.ts` and YAML data in `callout.ts`
- Type `targetKeyDropdown` as `DropdownComponent` from obsidian instead of `any`
- Narrow frontmatter values to `string` via `String()` conversion at the render boundary and in `ChoproFile.key`

Eliminates all 9 `@typescript-eslint/no-explicit-any` warnings flagged after the TypeScript 6 upgrade.

## Test plan
- [x] `npm run build` (tsc + esbuild) passes
- [x] `npx jest` — 551 tests pass
- [x] `npx eslint .` — 0 warnings, 0 errors
- [x] `just check` — prettier and eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)