### PR TITLE
chore(manifest): satisfy plugin directory validator

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,10 +3,9 @@
     "name": "ChordPro Viewer",
     "version": "0.9.4",
     "minAppVersion": "1.4.0",
-    "description": "Render ChordPro format code blocks in Obsidian.",
+    "description": "Render ChordPro format code blocks.",
     "author": "Jason Heddings",
     "authorUrl": "https://github.com/jheddings",
     "fundingUrl": "https://github.com/sponsors/jheddings",
-    "isDesktopOnly": false,
-    "css": "styles.css"
+    "isDesktopOnly": false
 }


### PR DESCRIPTION
## Summary
The Obsidian plugin dashboard validator flagged two manifest issues:

- **Error** — description contains "Obsidian" (redundant in the plugin directory context). Dropped ` in Obsidian` from the description.
- **Warning** — `css` is not a recognized manifest field. `styles.css` is auto-loaded from the plugin folder, so the entry was a no-op. Removed.

## Test plan
- [ ] Re-run the plugin dashboard validation; both checks should clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)