### PR TITLE
fix(release): use conventional commit format for release commits

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -50,7 +50,7 @@ release bump="patch": preflight repo-guard
 	jq --arg v "$VERSION" --arg m "$MIN_APP" '. + {($v): $m}' versions.json > tmp.$$.json && mv tmp.$$.json versions.json
 	npx prettier --write package.json package-lock.json manifest.json versions.json
 	git add package.json package-lock.json manifest.json versions.json
-	git commit -m "obsidian-chopro-$VERSION"
+	git commit -m "chore(release): $VERSION"
 	git tag -a "$VERSION" -m "$VERSION"
 	git push && git push --tags
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -44,6 +44,7 @@ commit_preprocessors = [
 
 commit_parsers = [
   # skip version bumps, lockfile maintenance, and merge commits
+  { message = "^chore\\(release\\):", skip = true },
   { message = "^bump version", skip = true },
   { message = "^chore\\(deps\\): lock file maintenance", skip = true },
   { message = "^[Mm]erge", skip = true },


### PR DESCRIPTION
## Summary
- Release commit message is now `chore(release): X.Y.Z` (conventional commits) instead of the plugin-name-prefixed format
- Updated `cliff.toml` skip rule to match where applicable

## Test plan
- [ ] Next `just release` produces a commit matching the new format
- [ ] git-cliff release notes do not include the release commit itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)